### PR TITLE
fix: Windows 窗口最小尺寸钳制，杜绝缩到极小无法放大

### DIFF
--- a/wezterm-gui/src/termwindow/resize.rs
+++ b/wezterm-gui/src/termwindow/resize.rs
@@ -41,6 +41,18 @@ impl super::TermWindow {
             log::trace!("new dimensions are zero: NOP!");
             return;
         }
+        // Catch the trigger for the "window shrinks to a tiny size" bug: log at
+        // warn level (visible without trace logging) whenever we're asked to
+        // resize below a usable floor, so the originating event is identifiable.
+        if dimensions.pixel_width < 400 || dimensions.pixel_height < 300 {
+            log::warn!(
+                "suspiciously small resize: new dims {:?} (was {:?}), window_state={:?}, live_resizing={}",
+                dimensions,
+                self.dimensions,
+                window_state,
+                live_resizing,
+            );
+        }
         if self.dimensions == dimensions && self.window_state == window_state {
             // It didn't really change
             log::trace!("dimensions didn't change NOP!");

--- a/window/src/os/windows/window.rs
+++ b/window/src/os/windows/window.rs
@@ -1218,6 +1218,31 @@ unsafe fn wm_nccalcsize(hwnd: HWND, _msg: UINT, wparam: WPARAM, lparam: LPARAM) 
     Some(0)
 }
 
+/// Enforce a minimum window size so a stray resize, DPI/monitor change, or
+/// font-size shrink can never collapse the window to a size where the
+/// integrated title buttons and resize borders become unusable — i.e. the
+/// "window goes tiny and can't be made larger again" failure. The guard in
+/// `session_state.rs` only covers relaunch; this covers live operation.
+unsafe fn wm_getminmaxinfo(
+    hwnd: HWND,
+    _msg: UINT,
+    _wparam: WPARAM,
+    lparam: LPARAM,
+) -> Option<LRESULT> {
+    // Logical minimum, scaled to physical pixels for the window's current DPI.
+    const MIN_LOGICAL_W: f64 = 400.0;
+    const MIN_LOGICAL_H: f64 = 300.0;
+
+    let mmi = (lparam as *mut MINMAXINFO).as_mut()?;
+    let dpi = GetDpiForWindow(hwnd);
+    let scale = if dpi == 0 { 1.0 } else { dpi as f64 / 96.0 };
+
+    mmi.ptMinTrackSize.x = (MIN_LOGICAL_W * scale).round() as i32;
+    mmi.ptMinTrackSize.y = (MIN_LOGICAL_H * scale).round() as i32;
+
+    Some(0)
+}
+
 unsafe fn wm_nchittest(hwnd: HWND, msg: UINT, wparam: WPARAM, lparam: LPARAM) -> Option<LRESULT> {
     let inner = rc_from_hwnd(hwnd)?;
     let inner = match inner.try_borrow() {
@@ -3040,6 +3065,7 @@ unsafe fn do_wnd_proc(hwnd: HWND, msg: UINT, wparam: WPARAM, lparam: LPARAM) -> 
             crate::spawn::SPAWN_QUEUE.run();
             None
         }
+        WM_GETMINMAXINFO => wm_getminmaxinfo(hwnd, msg, wparam, lparam),
         WM_SETTINGCHANGE | WM_DWMCOMPOSITIONCHANGED => apply_theme(hwnd),
         WM_IME_SETCONTEXT => ime_set_context(hwnd, msg, wparam, lparam),
         WM_IME_COMPOSITION => ime_composition(hwnd, msg, wparam, lparam),


### PR DESCRIPTION
## 问题

Windows 层没有任何运行时最小窗口尺寸约束（`session_state.rs` 的 800x480 下限只在重启恢复时生效）。字号缩小、DPI/显示器切换、贴边或异常 resize 都可能把窗口缩到标题栏按钮与缩放边都抓不住的程度，导致无法放大。

实测 v0.43 官方版：用 `SetWindowPos` 请求 50x40，窗口被缩到 **136x40**（只剩一条标题栏碎片）。

## 修复

- 新增 `WM_GETMINMAXINFO` 处理，将 `ptMinTrackSize` 钳到按 DPI 缩放的 **400x300 逻辑像素**。系统在所有 resize 路径（鼠标拖拽、程序调用、DPI 切换）强制执行该下限
- `resize()` 中新增 warn 级日志：任何把窗口往 <400x300 缩的请求都会被记录（含 window_state、live_resizing），便于定位触发源

## 自测（Windows 11, DPI 96）

| 场景 | 修复前 (v0.43) | 修复后 |
|------|---------------|--------|
| `SetWindowPos` 请求 50x40 | 缩到 136x40 | 停在 **400x300** |
| 最小尺寸下窗口可用性 | 内容不可见 | 标题栏按钮/Tab 栏/终端/状态栏全部正常渲染 |
| 放大恢复 | — | 正常 |

终端输入输出正常，MCP Server 可连接（`unterm-cli session list` 正常返回）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)