### PR TITLE
fix: stabilize Windows debug health checks

### DIFF
--- a/wezterm-gui/src/cockpit/verification.rs
+++ b/wezterm-gui/src/cockpit/verification.rs
@@ -534,13 +534,22 @@ mod tests {
     fn stops_a_command_at_its_deadline() {
         let dir = tempfile::tempdir().unwrap();
         let slow_command = if cfg!(windows) {
-            "ping -n 3 127.0.0.1 >nul"
+            "ping -n 6 127.0.0.1 >nul"
         } else {
-            "sleep 2"
+            "sleep 5"
         };
         let output = execute(dir.path(), slow_command, Duration::from_millis(25)).unwrap();
         assert!(output.timed_out);
-        assert!(output.duration_ms < 1_000);
+        // Windows launches taskkill.exe to terminate the complete descendant
+        // tree. Process startup and tree teardown can occasionally exceed one
+        // second on a busy CI/desktop host, but must still finish well before
+        // the command's natural five-second duration.
+        let cleanup_deadline_ms = if cfg!(windows) { 3_000 } else { 1_000 };
+        assert!(
+            output.duration_ms < cleanup_deadline_ms,
+            "timed-out command cleanup took {}ms",
+            output.duration_ms
+        );
     }
 
     #[test]

--- a/wezterm-gui/src/mcp/handler.rs
+++ b/wezterm-gui/src/mcp/handler.rs
@@ -1454,13 +1454,14 @@ impl McpHandler {
             .map(|mux| mux.iter_panes().len())
             .unwrap_or_default();
         let config = config::configuration();
+        let instance = crate::server_info::read_current();
 
         Ok(json!({
             "status": if mux_available { "ok" } else { "degraded" },
             "engine": "Unterm (WezTerm)",
             "mcp": {
                 "bind": "127.0.0.1",
-                "port": 19876,
+                "port": instance.mcp_port,
                 "auth": "token",
             },
             "mux": {


### PR DESCRIPTION
## What changed

- Make the Windows verification timeout test use a five-second command and a Windows-specific cleanup allowance, while still requiring termination well before natural completion.
- Report the current Unterm process's actual MCP port from `server.health` instead of hard-coding alpha's default `19876`.

## Why

Windows starts `taskkill.exe` to terminate a complete descendant process tree. On a busy machine that cleanup can occasionally exceed one second, causing a false-negative test even though the command is correctly marked timed out and terminated. Multi-instance Debug validation also showed that bravo was reachable on `19878` while health metadata incorrectly reported `19876`.

## Impact

Windows Debug tests are stable under realistic process cleanup latency, and agents receive correct health metadata when multiple Unterm instances are running.

## Validation

- Windows Debug GUI and CLI build: passed
- `cargo test -p config`: 12/12 passed
- Targeted timeout test: 10 consecutive passes
- `cargo test -p unterm`: 148/148 passed
- Independent Debug instance `bravo` self-test: all checks passed
- `server.health` for bravo reports its actual MCP port `19878`
- `git diff --check`: passed