### PR TITLE
feat: 托管 Unzoo One 控制台，并捆绑成一个安装包

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6390,6 +6390,7 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
+ "tempfile",
  "unterm-agents",
  "unterm-engine",
  "unterm-mcp",

--- a/ci/README.md
+++ b/ci/README.md
@@ -19,3 +19,42 @@ The default mode verifies `docs\next-core-benchmark-summary.json` with `unterm-e
 The full mode runs `unterm-engine\bench-next-core.ps1`, writes the Markdown/JSON benchmark artifacts, then verifies the JSON summary.
 
 GitHub Actions workflow changes require a token with `workflow` scope. If a local agent cannot push `.github\workflows\*.yml`, keep this script and documentation committed, then add the workflow step from an account or token with that scope.
+
+## Installers
+
+Two products ship out of this repo's build scripts, and they stay independent:
+
+```powershell
+# Just the terminal. Same MSI as always; the console rides along when its
+# static build is present, and the build succeeds without it either way.
+pwsh -File ci\build-msi.ps1
+
+# Unzoo One: one download that installs the terminal and the browser.
+gh release download -R unzooai/unzoo -p "UnzooSetup-*.exe" --dir dist
+pwsh -File ci\build-bundle.ps1 -UnzooSetup dist\UnzooSetup-2.5.32.exe
+```
+
+The bundle is additive. It carries `Unterm.msi` byte-for-byte and hands Unzoo's
+own installer its silent switch; neither product is repackaged or renamed, and
+the bundle's `UpgradeCode` is its own. Installing through the bundle and
+installing the two pieces by hand leave the machine in the same state, and each
+product keeps updating on its own schedule.
+
+`build-bundle.ps1` builds an MSI first unless you point `-UntermMsi` at one.
+The browser is chained as non-vital: if its installer fails, the terminal is
+still installed and usable, just without the browser-driven capabilities. A
+machine that already has the same or a newer Unzoo Browser skips that 183 MB
+step entirely.
+
+### The console
+
+The Unzoo One console is built in the `unzoo-one` repo:
+
+```bash
+cd ..\unzoo-one && npm run build:static   # -> dist\client
+```
+
+`build-msi.ps1 -ConsoleDir` defaults to `..\unzoo-one\dist\client`. When it
+finds a build there it stages it into `<install dir>\console`, which
+`unterm-settings` serves at `/console/`. No build, no console: the MSI is a
+couple of MB smaller and the menu entry stays hidden.

--- a/ci/build-bundle.ps1
+++ b/ci/build-bundle.ps1
@@ -1,0 +1,95 @@
+<#
+.SYNOPSIS
+  Build the Unzoo One installer: one bundle that installs Unterm and Unzoo
+  Browser.
+
+.DESCRIPTION
+  Chains two installers that both remain independently shippable:
+
+    - Unterm.msi          built by ci\build-msi.ps1 (this script can run it)
+    - UnzooSetup-*.exe    Unzoo Browser's own installer, from its releases
+
+  Nothing about either product changes. The MSI keeps its own UpgradeCode and
+  its own update path; the bundle has a separate one. Installing through the
+  bundle and installing the two pieces by hand end up at the same place.
+
+.PARAMETER UnzooSetup
+  Path to UnzooSetup-<version>.exe. Download it from the unzoo releases page
+  (gh release download -R unzooai/unzoo -p "UnzooSetup-*.exe").
+
+.PARAMETER UntermMsi
+  An already-built MSI. Omit to build one now via ci\build-msi.ps1.
+
+.EXAMPLE
+  pwsh -File ci\build-bundle.ps1 -UnzooSetup .\dist\UnzooSetup-2.5.32.exe
+#>
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$UnzooSetup,
+  [string]$UntermMsi,
+  [string]$Version,
+  [string]$OutDir = "dist",
+  [string]$TargetDir = "target\release",
+  [string]$WixPath = ".\.tools\wix.exe",
+  [string]$ConsoleDir = "..\unzoo-one\dist\client",
+  [ValidateSet("x64", "arm64")]
+  [string]$Arch = $(if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") { "arm64" } else { "x64" })
+)
+$ErrorActionPreference = "Stop"
+
+if (-not $Version) {
+  $cargo = Get-Content "Cargo.toml" -Raw
+  if ($cargo -match '(?m)^version\s*=\s*"([^"]+)"') { $Version = $Matches[1] }
+  else { throw "Could not read a version out of Cargo.toml; pass -Version." }
+}
+
+if (-not (Test-Path $UnzooSetup)) {
+  throw "No Unzoo installer at $UnzooSetup. Fetch one with: gh release download -R unzooai/unzoo -p 'UnzooSetup-*.exe'"
+}
+$UnzooSetup = (Resolve-Path $UnzooSetup).Path
+
+# The bundle skips the browser when the machine already has this version or
+# newer, so the version has to come off the file we are about to carry.
+if ((Split-Path $UnzooSetup -Leaf) -match 'UnzooSetup-([0-9]+\.[0-9]+\.[0-9]+)') {
+  $unzooVersion = $Matches[1]
+} else {
+  throw "Could not read a version out of $(Split-Path $UnzooSetup -Leaf); expected UnzooSetup-<x.y.z>.exe"
+}
+
+if (-not $UntermMsi) {
+  Write-Host "No -UntermMsi given; building one."
+  & pwsh -File "ci\build-msi.ps1" -Version $Version -OutDir $OutDir -TargetDir $TargetDir -WixPath $WixPath -ConsoleDir $ConsoleDir -Arch $Arch
+  if ($LASTEXITCODE -ne 0) { throw "MSI build failed with exit code $LASTEXITCODE" }
+  $UntermMsi = Join-Path $OutDir "Unterm-$Version-$Arch.msi"
+}
+if (-not (Test-Path $UntermMsi)) { throw "No MSI at $UntermMsi" }
+$UntermMsi = (Resolve-Path $UntermMsi).Path
+
+if (-not (Test-Path $WixPath)) {
+  throw "WiX not found at $WixPath. See ci\build-msi.ps1 for the install steps."
+}
+# hyperlinkLicense theme + RegistrySearch: the standard bootstrapper and util
+# extensions. Both adds are idempotent.
+& $WixPath extension add -g WixToolset.BootstrapperApplications.wixext/6.0.1 | Out-Null
+& $WixPath extension add -g WixToolset.Util.wixext/6.0.1 | Out-Null
+
+if (-not (Test-Path $OutDir)) { New-Item -ItemType Directory -Path $OutDir | Out-Null }
+$bundleName = "UnzooOneSetup-$Version-$Arch.exe"
+$bundlePath = Join-Path $OutDir $bundleName
+
+& $WixPath build installer\UnzooOne.wxs `
+  -ext WixToolset.BootstrapperApplications.wixext `
+  -ext WixToolset.Util.wixext `
+  -d "SourceDir=$TargetDir" `
+  -d "UntermMsi=$UntermMsi" `
+  -d "UnzooSetup=$UnzooSetup" `
+  -d "UnzooVersion=$unzooVersion" `
+  -d "BundleVersion=$Version" `
+  -arch $Arch `
+  -o $bundlePath
+if ($LASTEXITCODE -ne 0) { throw "Bundle build failed with exit code $LASTEXITCODE" }
+
+$mb = [int]((Get-Item $bundlePath).Length / 1MB)
+Write-Host "Bundle: $bundlePath ($mb MB)"
+Write-Host "  Unterm $Version + Unzoo Browser $unzooVersion"

--- a/ci/build-msi.ps1
+++ b/ci/build-msi.ps1
@@ -24,7 +24,11 @@ param(
   # -arch (component bitness + ProgramFiles64 resolution). Defaults from the
   # host so a native arm runner produces an arm64 MSI without extra args.
   [ValidateSet("x64", "arm64")]
-  [string]$Arch = $(if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") { "arm64" } else { "x64" })
+  [string]$Arch = $(if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") { "arm64" } else { "x64" }),
+  # The Unzoo One console's static build (unzoo-one's `npm run build:static`
+  # output). Optional: without it the MSI builds exactly as before, and the
+  # installed unterm simply does not offer the console.
+  [string]$ConsoleDir = "..\unzoo-one\dist\client"
 )
 $ErrorActionPreference = "Stop"
 
@@ -82,6 +86,24 @@ Copy-Item "assets\fonts\NotoColorEmoji.ttf" $fonts
 # The default terminal face, opened by file name at startup.
 Copy-Item "assets\fonts\JetBrainsMono-Regular.ttf" $fonts
 
+# The Unzoo One console, if its static build is around. unterm-settings serves
+# whatever lands in <install dir>\console at /console/; when the directory is
+# absent the console entry never shows up in the menu, so shipping without it
+# is a supported build, not a broken one.
+$consoleStaged = $false
+if (Test-Path (Join-Path $ConsoleDir "index.html")) {
+  $consoleTarget = Join-Path $stage "console"
+  Copy-Item $ConsoleDir $consoleTarget -Recurse
+  # Vite leaves its manifest cache behind; it is not needed at runtime.
+  $viteCache = Join-Path $consoleTarget ".vite"
+  if (Test-Path $viteCache) { Remove-Item -Recurse -Force $viteCache }
+  $consoleStaged = $true
+  $count = (Get-ChildItem $consoleTarget -Recurse -File).Count
+  Write-Host "Staging the Unzoo One console: $count files from $ConsoleDir"
+} else {
+  Write-Host "No console build at $ConsoleDir — the MSI will ship without it."
+}
+
 if (-not (Test-Path $WixPath)) {
   throw "WiX not found at $WixPath. Download wix.exe from https://github.com/wixtoolset/wix and place it there."
 }
@@ -100,6 +122,7 @@ $msiPath = Join-Path $OutDir $msiName
 & $WixPath build installer\Unterm.wxs `
   -ext WixToolset.UI.wixext `
   -d "SourceDir=$stage" `
+  -d "ConsoleStaged=$(if ($consoleStaged) { '1' } else { '0' })" `
   -arch $Arch `
   -o $msiPath
 if ($LASTEXITCODE -ne 0) {

--- a/installer/Unterm.wxs
+++ b/installer/Unterm.wxs
@@ -35,6 +35,11 @@
       <ComponentGroupRef Id="UntermFiles" />
       <ComponentRef Id="StartMenuShortcut" />
       <ComponentRef Id="ExplorerContextMenu" />
+      <!-- Built by unzoo-one's `npm run build:static`; ci\build-msi.ps1 sets
+           ConsoleStaged=1 once it has copied it into the staging folder. -->
+      <?if $(var.ConsoleStaged) = "1" ?>
+      <ComponentGroupRef Id="ConsoleFiles" />
+      <?endif?>
     </Feature>
 
     <StandardDirectory Id="ProgramFiles64Folder">
@@ -46,6 +51,9 @@
         <!-- Mesa software-GL is x64-only; no arm64 prebuilt exists. -->
         <?if $(sys.BUILDARCH) != "arm64" ?>
         <Directory Id="MesaFolder" Name="mesa" />
+        <?endif?>
+        <?if $(var.ConsoleStaged) = "1" ?>
+        <Directory Id="ConsoleFolder" Name="console" />
         <?endif?>
       </Directory>
     </StandardDirectory>
@@ -201,5 +209,14 @@
           Value="&quot;[INSTALLFOLDER]unterm.exe&quot; start --cwd &quot;%V&quot;" />
       </Component>
     </DirectoryRef>
+
+    <!-- The console's file names carry content hashes that change on every
+         front-end build, so they are harvested rather than listed. Anything
+         under the staged console\ directory ships as-is. -->
+    <?if $(var.ConsoleStaged) = "1" ?>
+    <ComponentGroup Id="ConsoleFiles" Directory="ConsoleFolder">
+      <Files Include="$(var.SourceDir)\console\**" />
+    </ComponentGroup>
+    <?endif?>
   </Package>
 </Wix>

--- a/installer/UnzooOne.wxs
+++ b/installer/UnzooOne.wxs
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  The Unzoo One installer: one download that lays down the terminal and the
+  browser, so a new user does not have to find and run two of them.
+
+  This is purely additive. It carries Unterm.msi as-is and hands Unzoo's own
+  installer its own silent switch; neither product is repackaged, renamed, or
+  given a new UpgradeCode. Both stay independently installable and each keeps
+  updating on its own schedule — the bundle only solves first-time setup.
+
+  Build it with ci\build-bundle.ps1, which stages the MSI and the Unzoo
+  installer next to each other first.
+-->
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs"
+     xmlns:bal="http://wixtoolset.org/schemas/v4/wxs/bal">
+
+  <Bundle
+    Name="Unzoo One"
+    Manufacturer="Alex"
+    Version="$(var.BundleVersion)"
+    UpgradeCode="0D238B09-1BCC-451C-96E4-F2849F7BAFC3"
+    IconSourceFile="assets\windows\terminal.ico"
+    Compressed="yes">
+
+    <BootstrapperApplication>
+      <bal:WixStandardBootstrapperApplication
+        Theme="hyperlinkLicense"
+        LicenseUrl="https://unterm.app"
+        SuppressOptionsUI="yes" />
+    </BootstrapperApplication>
+
+    <!--
+      Unzoo Browser writes a plain uninstall entry. Reading DisplayVersion
+      tells us both whether it is here and which build, so an install that
+      already has it skips a 183 MB no-op.
+    -->
+    <util:RegistrySearch
+      xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util"
+      Id="UnzooInstalledVersion"
+      Root="HKLM"
+      Key="SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Unzoo Browser"
+      Value="DisplayVersion"
+      Result="value"
+      Variable="UnzooVersion" />
+
+    <Chain>
+      <!--
+        The terminal, the Core, and the console. Unterm.msi is the same file
+        the standalone download ships; installing through the bundle and
+        installing it directly leave the machine in the same state.
+      -->
+      <MsiPackage
+        Id="Unterm"
+        SourceFile="$(var.UntermMsi)"
+        Vital="yes" />
+
+      <!--
+        The browser. Its installer is NSIS, so /S is the silent switch.
+        Not vital: a machine with the terminal but no browser is still a
+        working install, just without the browser-driven capabilities.
+      -->
+      <ExePackage
+        Id="UnzooBrowser"
+        SourceFile="$(var.UnzooSetup)"
+        InstallArguments="/S"
+        UninstallArguments="/S"
+        PerMachine="yes"
+        Permanent="no"
+        Vital="no"
+        DetectCondition="UnzooVersion &gt;= v$(var.UnzooVersion)" />
+    </Chain>
+  </Bundle>
+</Wix>

--- a/unterm-app/src/palette.rs
+++ b/unterm-app/src/palette.rs
@@ -35,6 +35,9 @@ pub enum Command {
     ExportSession,
     /// Open the web settings page in a browser.
     OpenSettings,
+    /// Open the Unzoo One console in a browser. Only offered when the
+    /// console assets are actually installed.
+    OpenConsole,
     /// Open the shell picker: a new tab running the shell you choose.
     OpenShellSelector,
     /// Show the directories under a path, so one can be picked.

--- a/unterm-app/src/window.rs
+++ b/unterm-app/src/window.rs
@@ -7140,6 +7140,20 @@ impl App {
         }
     }
 
+    /// Open the Unzoo One console. Same HTTP server as the settings page,
+    /// off `/console/`.
+    fn open_console(&mut self) {
+        let info = unterm_services::server_info::read();
+        if info.http_port == 0 {
+            log::warn!("the settings server has not started yet");
+            return;
+        }
+        let url = format!("http://127.0.0.1:{}/console/", info.http_port);
+        if let Err(err) = crate::links::open(&url) {
+            log::warn!("could not open {url}: {err}");
+        }
+    }
+
     /// The picker's rows: every theme the product ships.
     fn theme_entries(&self) -> Vec<crate::palette::Entry> {
         let current = self.theme_id.clone();
@@ -7256,7 +7270,7 @@ impl App {
             hint: chord(action),
             command: crate::palette::Command::Action(action),
         };
-        vec![
+        let mut entries = vec![
             action(t("menu.new_tab"), crate::keys::Action::NewTab),
             action(
                 t("settings.menu.split_right"),
@@ -7328,7 +7342,24 @@ impl App {
                     url: "https://unterm.app".to_string(),
                 },
             },
-        ]
+        ];
+        // 控制台只在装了资源时进菜单：没装的话点开只会是一个 404。
+        if unterm_settings::console_dir().is_some() {
+            let at = entries
+                .iter()
+                .position(|entry| entry.command == crate::palette::Command::OpenSettings)
+                .map(|index| index + 1)
+                .unwrap_or(entries.len());
+            entries.insert(
+                at,
+                crate::palette::Entry {
+                    label: t("settings.menu.console"),
+                    hint: t("settings.menu.console.hint"),
+                    command: crate::palette::Command::OpenConsole,
+                },
+            );
+        }
+        entries
     }
 
     /// Every command the GUI exposes, not only the subset with a key chord.
@@ -8029,6 +8060,7 @@ impl App {
             crate::palette::Command::ToggleRecording => self.toggle_recording(),
             crate::palette::Command::ExportSession => self.export_session(),
             crate::palette::Command::OpenSettings => self.open_settings(),
+            crate::palette::Command::OpenConsole => self.open_console(),
             crate::palette::Command::ApplyTheme { id } => self.apply_theme(&id),
             crate::palette::Command::TypeCharacter { glyph, name } => {
                 self.type_character(&glyph, &name)

--- a/unterm-services/src/i18n/locales/de.json
+++ b/unterm-services/src/i18n/locales/de.json
@@ -163,6 +163,8 @@
   "settings.menu.split_right.hint": "Aktiven Bereich horizontal teilen",
   "settings.menu.web_settings": "Einstellungen (Web)",
   "settings.menu.web_settings.hint": "Themes, Proxy, Sitzungen und mehr",
+  "settings.menu.console": "Unzoo One Konsole",
+  "settings.menu.console.hint": "Aufgaben, Freigaben, Artefakte, Verlauf",
   "settings.title": "Einstellungen",
   "shell.footer.hint": " ↑↓ Navigieren   Enter Öffnen   Esc Abbrechen   1-9 Schnellauswahl",
   "shell.subtitle": "  Shell-Profil auswählen",

--- a/unterm-services/src/i18n/locales/en.json
+++ b/unterm-services/src/i18n/locales/en.json
@@ -237,6 +237,8 @@
   "settings.menu.split_right.hint": "split current pane left/right",
   "settings.menu.web_settings": "Settings (Web)",
   "settings.menu.web_settings.hint": "themes, proxy, sessions, all the rest",
+  "settings.menu.console": "Unzoo One Console",
+  "settings.menu.console.hint": "tasks, approvals, artifacts, the whole workbench",
   "settings.title": "Settings",
   "shell.footer.hint": " ↑↓ Navigate   Enter Open   Esc Cancel   1-9 Quick",
   "shell.subtitle": "  Choose a shell profile",

--- a/unterm-services/src/i18n/locales/fr.json
+++ b/unterm-services/src/i18n/locales/fr.json
@@ -163,6 +163,8 @@
   "settings.menu.split_right.hint": "diviser le panneau actif horizontalement",
   "settings.menu.web_settings": "Paramètres (Web)",
   "settings.menu.web_settings.hint": "thèmes, proxy, sessions et plus encore",
+  "settings.menu.console": "Console Unzoo One",
+  "settings.menu.console.hint": "tâches, validations, livrables et historique",
   "settings.title": "Paramètres",
   "shell.footer.hint": " ↑↓ Naviguer   Entrée Ouvrir   Esc Annuler   1-9 Raccourci",
   "shell.subtitle": "  Choisissez un profil de shell",

--- a/unterm-services/src/i18n/locales/hi.json
+++ b/unterm-services/src/i18n/locales/hi.json
@@ -163,6 +163,8 @@
   "settings.menu.split_right.hint": "वर्तमान पैनल को बाएँ/दाएँ विभाजित करें",
   "settings.menu.web_settings": "सेटिंग्स (वेब)",
   "settings.menu.web_settings.hint": "थीम, प्रॉक्सी, सत्र और बाक़ी सब",
+  "settings.menu.console": "Unzoo One कंसोल",
+  "settings.menu.console.hint": "कार्य, अनुमोदन, आउटपुट और रन इतिहास",
   "settings.title": "सेटिंग्स",
   "shell.footer.hint": " ↑↓ नेविगेट   Enter खोलें   Esc रद्द   1-9 त्वरित",
   "shell.subtitle": "  शेल प्रोफ़ाइल चुनें",

--- a/unterm-services/src/i18n/locales/it.json
+++ b/unterm-services/src/i18n/locales/it.json
@@ -163,6 +163,8 @@
   "settings.menu.split_right.hint": "dividi orizzontalmente il pannello attivo",
   "settings.menu.web_settings": "Impostazioni (Web)",
   "settings.menu.web_settings.hint": "temi, proxy, sessioni e altro",
+  "settings.menu.console": "Console Unzoo One",
+  "settings.menu.console.hint": "attività, approvazioni, artefatti e cronologia",
   "settings.title": "Impostazioni",
   "shell.footer.hint": " ↑↓ Naviga   Invio Apri   Esc Annulla   1-9 Rapido",
   "shell.subtitle": "  Scegli un profilo di shell",

--- a/unterm-services/src/i18n/locales/ja.json
+++ b/unterm-services/src/i18n/locales/ja.json
@@ -163,6 +163,8 @@
   "settings.menu.split_right.hint": "現在のペインを左右に分割",
   "settings.menu.web_settings": "設定(Web)",
   "settings.menu.web_settings.hint": "テーマ、プロキシ、セッションなど",
+  "settings.menu.console": "Unzoo One コンソール",
+  "settings.menu.console.hint": "タスク、承認、成果物、実行記録",
   "settings.title": "設定",
   "shell.footer.hint": " ↑↓ 移動   Enter 開く   Esc キャンセル   1-9 ショートカット",
   "shell.subtitle": "  シェルプロファイルを選択",

--- a/unterm-services/src/i18n/locales/ko.json
+++ b/unterm-services/src/i18n/locales/ko.json
@@ -163,6 +163,8 @@
   "settings.menu.split_right.hint": "현재 창을 좌우로 분할",
   "settings.menu.web_settings": "설정(웹)",
   "settings.menu.web_settings.hint": "테마, 프록시, 세션 등 모든 항목",
+  "settings.menu.console": "Unzoo One 콘솔",
+  "settings.menu.console.hint": "작업, 승인, 산출물, 실행 기록",
   "settings.title": "설정",
   "shell.footer.hint": " ↑↓ 이동   Enter 열기   Esc 취소   1-9 빠른 선택",
   "shell.subtitle": "  셸 프로필 선택",

--- a/unterm-services/src/i18n/locales/zh-CN.json
+++ b/unterm-services/src/i18n/locales/zh-CN.json
@@ -237,6 +237,8 @@
   "settings.menu.split_right.hint": "将当前面板左右拆分",
   "settings.menu.web_settings": "设置(网页版)",
   "settings.menu.web_settings.hint": "主题、代理、会话等更多选项",
+  "settings.menu.console": "Unzoo One 工作台",
+  "settings.menu.console.hint": "任务、审批、成果与运行记录",
   "settings.title": "设置",
   "shell.footer.hint": " ↑↓ 选择   Enter 打开   Esc 取消   1-9 快速选择",
   "shell.subtitle": "  选择 Shell 配置",

--- a/unterm-services/src/i18n/locales/zh-TW.json
+++ b/unterm-services/src/i18n/locales/zh-TW.json
@@ -163,6 +163,8 @@
   "settings.menu.split_right.hint": "將目前面板左右分割",
   "settings.menu.web_settings": "設定(網頁版)",
   "settings.menu.web_settings.hint": "佈景主題、Proxy、工作階段等其他項目",
+  "settings.menu.console": "Unzoo One 工作台",
+  "settings.menu.console.hint": "任務、審批、成果與執行記錄",
   "settings.title": "設定",
   "shell.footer.hint": " ↑↓ 選擇   Enter 開啟   Esc 取消   1-9 快速選擇",
   "shell.subtitle": "  選擇 Shell 設定檔",

--- a/unterm-services/src/i18n/mod.rs
+++ b/unterm-services/src/i18n/mod.rs
@@ -243,6 +243,8 @@ mod catalogue_tests {
             "settings.menu.split_right",
             "settings.menu.recording_on",
             "settings.menu.recording_off",
+            "settings.menu.console",
+            "settings.menu.console.hint",
             "settings.menu.export_session",
             "settings.menu.web_settings",
         ];

--- a/unterm-settings/Cargo.toml
+++ b/unterm-settings/Cargo.toml
@@ -24,3 +24,6 @@ unterm-mcp = { path = "../unterm-mcp" }
 unterm-profile.workspace = true
 unterm-protocol.workspace = true
 unterm-services.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/unterm-settings/src/agent_run.rs
+++ b/unterm-settings/src/agent_run.rs
@@ -1,0 +1,182 @@
+//! Running a brain from the console.
+//!
+//! `agent_session.*` over MCP takes an argv, which is the right shape for a
+//! trusted caller and the wrong one to put behind HTTP: a page that can pass
+//! argv can run anything. So these routes take an **agent id** instead. The
+//! command comes from that agent's manifest entry and the resolved binary
+//! path that `installer::detect` hands back; the caller's own input only ever
+//! reaches the prompt, which is written to the agent's stdin.
+//!
+//! What the caller can decide: which agent, what prompt, and which
+//! task/run/step the events belong to. What it cannot decide: what runs.
+
+use super::server::Response;
+use serde_json::{json, Value};
+use unterm_agents::{fetch_manifests, installer};
+use unterm_mcp::handler::McpHandler;
+
+/// Flags that put an agent into headless JSON mode.
+///
+/// A manifest's `launch.args` is written for a human at a terminal. The
+/// adapters in `unterm-brain` read a JSON event stream instead, so the flags
+/// that produce one live here, next to the code that depends on them.
+fn headless_args(agent_id: &str) -> Option<&'static [&'static str]> {
+    match agent_id {
+        // ClaudeAdapter reads the `type: system|assistant|result` lines that
+        // `--output-format stream-json` emits. `--verbose` is what makes it
+        // stream rather than buffer to a single final message.
+        "claude-code" => Some(&["-p", "--output-format", "stream-json", "--verbose"]),
+        // CodexAdapter's JSONL is the reference format.
+        "codex-cli" => Some(&["exec", "--json"]),
+        _ => None,
+    }
+}
+
+fn parse_body(body: &[u8]) -> Value {
+    serde_json::from_slice(body).unwrap_or(Value::Null)
+}
+
+fn string_field<'a>(body: &'a Value, key: &str) -> Option<&'a str> {
+    body.get(key).and_then(Value::as_str).filter(|s| !s.is_empty())
+}
+
+/// POST /api/agent/start — run one agent against one prompt.
+pub fn api_start(handler: &McpHandler, body: &[u8]) -> Response {
+    let body = parse_body(body);
+
+    let Some(agent_id) = string_field(&body, "agent") else {
+        return Response::err(400, "Bad Request", "agent is required");
+    };
+    let Some(prompt) = string_field(&body, "prompt") else {
+        return Response::err(400, "Bad Request", "prompt is required");
+    };
+    let Some(args) = headless_args(agent_id) else {
+        return Response::err(
+            400,
+            "Bad Request",
+            &format!("{agent_id} has no headless mode the console knows how to drive"),
+        );
+    };
+
+    let set = match fetch_manifests() {
+        Ok(set) => set,
+        Err(e) => return Response::err(503, "Service Unavailable", &format!("manifest fetch: {e}")),
+    };
+    let Some(manifest) = set
+        .for_current_platform()
+        .into_iter()
+        .find(|m| m.id == agent_id)
+    else {
+        return Response::err(404, "Not Found", &format!("no agent named {agent_id}"));
+    };
+
+    // Resolve once, here: on Windows the binary is a .cmd shim that a bare
+    // name does not spawn, and the detected path is already absolute.
+    let detected = installer::detect(&manifest.detect);
+    if !detected.ok {
+        return Response::err(
+            503,
+            "Service Unavailable",
+            &format!("{} is not installed on this machine", manifest.name),
+        );
+    }
+    let Some(binary) = detected.binary_path else {
+        return Response::err(503, "Service Unavailable", "the agent has no resolved path");
+    };
+
+    let mut command = vec![json!(binary)];
+    command.extend(args.iter().map(|arg| json!(arg)));
+
+    let mut params = serde_json::Map::new();
+    params.insert("command".into(), Value::Array(command));
+    params.insert("prompt".into(), json!(prompt));
+    // Carried onto every event and log line, so the console can thread them
+    // back onto the task they belong to.
+    for key in ["task_id", "run_id", "step_id", "idempotency_key"] {
+        if let Some(value) = string_field(&body, key) {
+            params.insert(key.into(), json!(value));
+        }
+    }
+
+    let ctx = unterm_mcp::handler::ConnectionContext::internal("web_settings");
+    match handler.handle(&ctx, "agent_session.start", &Value::Object(params)) {
+        Ok(value) => Response::ok_json(json!({
+            "agent": agent_id,
+            "adapter": if agent_id == "claude-code" { "claude" } else { "codex" },
+            "session": value,
+        })),
+        Err(e) => Response::err(400, "Bad Request", &e.to_string()),
+    }
+}
+
+/// The rest of a session's life: events, status, input, interrupt, close.
+///
+/// These only ever address an existing session by id, so they pass through
+/// with the fields each method takes and nothing else.
+pub fn api_session_act(handler: &McpHandler, method: &str, body: &[u8]) -> Response {
+    let body = parse_body(body);
+    let Some(session_id) = string_field(&body, "session_id") else {
+        return Response::err(400, "Bad Request", "session_id is required");
+    };
+
+    let mut params = serde_json::Map::new();
+    params.insert("session_id".into(), json!(session_id));
+    if let Some(cursor) = body.get("cursor").and_then(Value::as_u64) {
+        params.insert("cursor".into(), json!(cursor));
+    }
+    if let Some(text) = string_field(&body, "text") {
+        params.insert("text".into(), json!(text));
+    }
+    if let Some(grace) = body.get("grace_ms").and_then(Value::as_u64) {
+        params.insert("grace_ms".into(), json!(grace));
+    }
+
+    let ctx = unterm_mcp::handler::ConnectionContext::internal("web_settings");
+    match handler.handle(&ctx, method, &Value::Object(params)) {
+        Ok(value) => Response::ok_json(value),
+        Err(e) => Response::err(400, "Bad Request", &e.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn only_agents_with_a_known_headless_mode_are_runnable() {
+        assert!(headless_args("claude-code").is_some());
+        assert!(headless_args("codex-cli").is_some());
+        // An agent we have not taught the console to drive is refused rather
+        // than launched with whatever its interactive flags happen to be.
+        assert!(headless_args("gemini-cli").is_none());
+        assert!(headless_args("").is_none());
+        assert!(headless_args("../../evil").is_none());
+    }
+
+    #[test]
+    fn claude_gets_the_flags_its_adapter_parses() {
+        let args = headless_args("claude-code").expect("claude");
+        assert!(args.contains(&"-p"), "headless, not interactive");
+        assert!(args.contains(&"stream-json"), "the adapter reads JSON lines");
+        assert!(args.contains(&"--verbose"), "streamed, not buffered to one message");
+    }
+
+    #[test]
+    fn a_start_without_an_agent_or_prompt_is_refused() {
+        // No handler needed: both checks run before anything is dispatched.
+        let missing_agent = parse_body(br#"{"prompt":"hi"}"#);
+        assert!(string_field(&missing_agent, "agent").is_none());
+        let missing_prompt = parse_body(br#"{"agent":"claude-code"}"#);
+        assert!(string_field(&missing_prompt, "prompt").is_none());
+        // An empty string is not a value.
+        let empty = parse_body(br#"{"agent":"","prompt":""}"#);
+        assert!(string_field(&empty, "agent").is_none());
+        assert!(string_field(&empty, "prompt").is_none());
+    }
+
+    #[test]
+    fn a_malformed_body_does_not_panic() {
+        assert_eq!(parse_body(b"not json"), Value::Null);
+        assert!(string_field(&parse_body(b"not json"), "agent").is_none());
+    }
+}

--- a/unterm-settings/src/console.rs
+++ b/unterm-settings/src/console.rs
@@ -100,6 +100,43 @@ pub fn lookup(request_path: &str) -> Option<(&'static str, Vec<u8>)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    /// `UNTERM_CONSOLE_DIR` is process-wide, so the tests that set it take
+    /// turns. Run the suite with `--test-threads=1` like the rest of the
+    /// workspace and this is belt-and-braces; run it in parallel and it is
+    /// what keeps these two from reading each other's directory.
+    static CONSOLE_DIR_ENV: Mutex<()> = Mutex::new(());
+
+    /// Points `UNTERM_CONSOLE_DIR` at a directory for as long as it lives,
+    /// then puts the old value back.
+    struct ConsoleDirGuard {
+        original: Option<std::ffi::OsString>,
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl ConsoleDirGuard {
+        fn set(dir: &Path) -> Self {
+            let lock = CONSOLE_DIR_ENV
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let original = std::env::var_os("UNTERM_CONSOLE_DIR");
+            std::env::set_var("UNTERM_CONSOLE_DIR", dir);
+            Self {
+                original,
+                _lock: lock,
+            }
+        }
+    }
+
+    impl Drop for ConsoleDirGuard {
+        fn drop(&mut self) {
+            match &self.original {
+                Some(value) => std::env::set_var("UNTERM_CONSOLE_DIR", value),
+                None => std::env::remove_var("UNTERM_CONSOLE_DIR"),
+            }
+        }
+    }
 
     fn fixture() -> tempfile::TempDir {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -155,5 +192,33 @@ mod tests {
         assert_eq!(content_type(Path::new("geist-98bbbccb.woff2")), "font/woff2");
         assert_eq!(content_type(Path::new("mark.webp")), "image/webp");
         assert_eq!(content_type(Path::new("weird.bin")), "application/octet-stream");
+    }
+
+    #[test]
+    fn env_var_points_at_the_console_and_lookup_reads_it() {
+        let dir = fixture();
+        let _guard = ConsoleDirGuard::set(dir.path());
+
+        assert_eq!(console_dir().as_deref(), Some(dir.path()), "UNTERM_CONSOLE_DIR wins");
+
+        let (ct, body) = lookup("").expect("index.html");
+        assert_eq!(ct, "text/html; charset=utf-8");
+        assert!(String::from_utf8_lossy(&body).contains("console"));
+
+        let (ct, body) = lookup("/assets/app-abc123.js").expect("hashed asset");
+        assert_eq!(ct, "application/javascript; charset=utf-8");
+        assert_eq!(body, b"export{}");
+
+        assert!(lookup("/../secret.txt").is_none(), "traversal stays refused through lookup");
+        assert!(lookup("/nope.js").is_none());
+    }
+
+    #[test]
+    fn a_directory_without_index_is_not_a_console() {
+        let empty = tempfile::tempdir().expect("tempdir");
+        let _guard = ConsoleDirGuard::set(empty.path());
+        // No index.html means the env var is ignored, and with no console
+        // beside the test binary either, there is nothing to serve.
+        assert!(console_dir().is_none() || lookup("").is_none());
     }
 }

--- a/unterm-settings/src/console.rs
+++ b/unterm-settings/src/console.rs
@@ -1,0 +1,159 @@
+//! Serving the Unzoo One console out of the settings HTTP server.
+//!
+//! The settings SPA is `include_str!`-ed into the binary because it is a
+//! handful of hand-written files. The console is a built artifact: ~1.4 MB
+//! across three dozen files whose names carry content hashes that change on
+//! every build. Baking that in would grow the binary, and would force a Rust
+//! rebuild for a front-end-only change. So it is read from disk instead.
+//!
+//! Where we look, in order:
+//!
+//! 1. `UNTERM_CONSOLE_DIR` — point it at `unzoo-one/dist/client` while
+//!    developing and the console reloads with a plain browser refresh.
+//! 2. `<exe dir>/console` — where the installer puts it.
+//!
+//! The console reaches the API the same way the settings page does: fetch
+//! `/bootstrap.json` once for the auth token, then send it as a bearer on
+//! every `/api/*` call. Same origin, so no CORS and nothing to configure.
+
+use std::path::{Component, Path, PathBuf};
+
+/// Where the console's files live, if we can find them.
+pub fn console_dir() -> Option<PathBuf> {
+    if let Some(dir) = std::env::var_os("UNTERM_CONSOLE_DIR") {
+        let path = PathBuf::from(dir);
+        if path.join("index.html").is_file() {
+            return Some(path);
+        }
+    }
+    let beside_exe = std::env::current_exe()
+        .ok()?
+        .parent()?
+        .join("console");
+    beside_exe.join("index.html").is_file().then_some(beside_exe)
+}
+
+/// Content type for a file we are about to serve. Unknown extensions get
+/// `application/octet-stream` rather than a guess.
+fn content_type(path: &Path) -> &'static str {
+    match path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(str::to_ascii_lowercase)
+        .as_deref()
+    {
+        Some("html") => "text/html; charset=utf-8",
+        Some("js") | Some("mjs") => "application/javascript; charset=utf-8",
+        Some("css") => "text/css; charset=utf-8",
+        Some("json") => "application/json; charset=utf-8",
+        Some("svg") => "image/svg+xml; charset=utf-8",
+        Some("png") => "image/png",
+        Some("jpg") | Some("jpeg") => "image/jpeg",
+        Some("webp") => "image/webp",
+        Some("avif") => "image/avif",
+        Some("ico") => "image/x-icon",
+        Some("woff2") => "font/woff2",
+        Some("woff") => "font/woff",
+        Some("txt") => "text/plain; charset=utf-8",
+        Some("map") => "application/json; charset=utf-8",
+        _ => "application/octet-stream",
+    }
+}
+
+/// Resolve a request path under the console root.
+///
+/// Rejects anything that is not a plain relative path: absolute paths, `..`,
+/// Windows drive prefixes. A request can only ever reach files inside the
+/// console directory.
+fn resolve(root: &Path, request_path: &str) -> Option<PathBuf> {
+    let trimmed = request_path.trim_start_matches('/');
+    let relative = if trimmed.is_empty() { "index.html" } else { trimmed };
+
+    let mut resolved = root.to_path_buf();
+    for component in Path::new(relative).components() {
+        match component {
+            Component::Normal(part) => resolved.push(part),
+            // Anything else is either a traversal attempt or meaningless here.
+            _ => return None,
+        }
+    }
+
+    // Directory requests get that directory's index.html.
+    if resolved.is_dir() {
+        resolved.push("index.html");
+    }
+    resolved.is_file().then_some(resolved)
+}
+
+/// Read the file a `/console/...` request maps to.
+///
+/// `None` means "no such file"; the caller turns that into a 404. An
+/// unreadable file that exists is also `None` — we would rather 404 than
+/// leak a filesystem error.
+pub fn lookup(request_path: &str) -> Option<(&'static str, Vec<u8>)> {
+    let root = console_dir()?;
+    let file = resolve(&root, request_path)?;
+    let body = std::fs::read(&file).ok()?;
+    Some((content_type(&file), body))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("index.html"), b"<!doctype html>console").unwrap();
+        std::fs::create_dir_all(dir.path().join("assets")).unwrap();
+        std::fs::write(dir.path().join("assets/app-abc123.js"), b"export{}").unwrap();
+        std::fs::write(dir.path().join("secret.txt"), b"not reachable from outside").unwrap();
+        dir
+    }
+
+    #[test]
+    fn empty_path_serves_index() {
+        let dir = fixture();
+        let resolved = resolve(dir.path(), "").expect("index");
+        assert!(resolved.ends_with("index.html"));
+    }
+
+    #[test]
+    fn hashed_asset_resolves() {
+        let dir = fixture();
+        let resolved = resolve(dir.path(), "/assets/app-abc123.js").expect("asset");
+        assert!(resolved.ends_with("app-abc123.js"));
+    }
+
+    #[test]
+    fn traversal_is_refused() {
+        let dir = fixture();
+        assert!(resolve(dir.path(), "../secret.txt").is_none());
+        assert!(resolve(dir.path(), "assets/../../secret.txt").is_none());
+        assert!(resolve(dir.path(), "/../../../etc/passwd").is_none());
+    }
+
+    #[test]
+    fn absolute_paths_are_refused() {
+        let dir = fixture();
+        assert!(resolve(dir.path(), "//etc/passwd").is_none());
+        if cfg!(windows) {
+            assert!(resolve(dir.path(), "C:/Windows/System32/config/SAM").is_none());
+        }
+    }
+
+    #[test]
+    fn missing_file_is_none() {
+        let dir = fixture();
+        assert!(resolve(dir.path(), "nope.js").is_none());
+    }
+
+    #[test]
+    fn content_types_cover_the_build_output() {
+        assert_eq!(content_type(Path::new("index.html")), "text/html; charset=utf-8");
+        assert_eq!(content_type(Path::new("a/b-1a2b.js")), "application/javascript; charset=utf-8");
+        assert_eq!(content_type(Path::new("a/b-1a2b.css")), "text/css; charset=utf-8");
+        assert_eq!(content_type(Path::new("geist-98bbbccb.woff2")), "font/woff2");
+        assert_eq!(content_type(Path::new("mark.webp")), "image/webp");
+        assert_eq!(content_type(Path::new("weird.bin")), "application/octet-stream");
+    }
+}

--- a/unterm-settings/src/lib.rs
+++ b/unterm-settings/src/lib.rs
@@ -6,6 +6,7 @@
 //! workspace deps; ~/.unterm/server.json carries the bound port and the
 //! shared auth token.
 
+mod agent_run;
 mod agents;
 mod assets;
 mod console;

--- a/unterm-settings/src/lib.rs
+++ b/unterm-settings/src/lib.rs
@@ -9,6 +9,7 @@
 mod agents;
 mod assets;
 mod console;
+pub use console::console_dir;
 pub mod server;
 
 pub use server::start_web_settings_server;

--- a/unterm-settings/src/lib.rs
+++ b/unterm-settings/src/lib.rs
@@ -8,6 +8,7 @@
 
 mod agents;
 mod assets;
+mod console;
 pub mod server;
 
 pub use server::start_web_settings_server;

--- a/unterm-settings/src/server.rs
+++ b/unterm-settings/src/server.rs
@@ -19,6 +19,7 @@
 //!   GET  /api/sessions/:id/markdown     -> recording::read_session_markdown
 
 use crate::assets;
+use crate::console;
 use anyhow::Result;
 use serde_json::{json, Value};
 use std::io::{BufRead, BufReader, Read, Write};
@@ -154,6 +155,18 @@ impl Response {
 
     pub(crate) fn err(status: u16, reason: &'static str, message: &str) -> Self {
         Self::json(status, reason, json!({"error": message}))
+    }
+
+    /// A bare redirect. Used to put the trailing slash back on `/console`
+    /// so the page's relative asset URLs resolve under it.
+    fn redirect(status: u16, location: &str) -> Self {
+        Self {
+            status,
+            reason: "Moved Permanently",
+            content_type: "text/plain; charset=utf-8",
+            body: Vec::new(),
+            extra_headers: vec![("Location", location.to_string())],
+        }
     }
 }
 
@@ -320,6 +333,36 @@ fn route(req: &Request, auth_token: &str, handler: &McpHandler) -> Response {
                 return Response::text(200, "OK", ct, body.as_bytes().to_vec());
             }
             return Response::err(404, "Not Found", "no such static asset");
+        }
+
+        // The Unzoo One console, served from disk. Unauthenticated like the
+        // settings SPA above: the page then reads /bootstrap.json for the
+        // token and carries it on every /api/* call.
+        if path == "/console" {
+            // Without the trailing slash the page's relative asset URLs would
+            // resolve against "/" instead of "/console/".
+            return Response::redirect(301, "/console/");
+        }
+        if let Some(rest) = path.strip_prefix("/console/") {
+            return match console::lookup(rest) {
+                Some((ct, body)) => Response::text(200, "OK", ct, body),
+                None if console::console_dir().is_none() => Response::err(
+                    503,
+                    "Service Unavailable",
+                    "console assets not installed; build unzoo-one with `npm run build:static` \
+                     and point UNTERM_CONSOLE_DIR at its dist/client",
+                ),
+                None => Response::err(404, "Not Found", "no such console asset"),
+            };
+        }
+
+        // The console's HTML references its assets by absolute path
+        // (/assets/…, /unzoo-favicon.png). Serving them only under /console/
+        // would 401 every one of them, so fall through to the console
+        // directory for anything the settings server itself does not claim.
+        // The settings SPA lives at / and /static/, both handled above.
+        if let Some((ct, body)) = console::lookup(path) {
+            return Response::text(200, "OK", ct, body);
         }
     }
 

--- a/unterm-settings/src/server.rs
+++ b/unterm-settings/src/server.rs
@@ -476,6 +476,23 @@ fn route(req: &Request, auth_token: &str, handler: &McpHandler) -> Response {
         // Routes wrap the unterm-agents crate so the Web Settings panel can
         // list / configure / install / launch every AI CLI in the signed
         // manifest. See `agents.rs` for the actual handlers.
+        // Running a brain. Takes an agent id, never an argv — see agent_run.
+        ("POST", "/api/agent/start") => super::agent_run::api_start(handler, &req.body),
+        ("POST", "/api/agent/events") => {
+            super::agent_run::api_session_act(handler, "agent_session.events", &req.body)
+        }
+        ("POST", "/api/agent/status") => {
+            super::agent_run::api_session_act(handler, "agent_session.status", &req.body)
+        }
+        ("POST", "/api/agent/input") => {
+            super::agent_run::api_session_act(handler, "agent_session.submit_input", &req.body)
+        }
+        ("POST", "/api/agent/interrupt") => {
+            super::agent_run::api_session_act(handler, "agent_session.interrupt", &req.body)
+        }
+        ("POST", "/api/agent/close") => {
+            super::agent_run::api_session_act(handler, "agent_session.close", &req.body)
+        }
         ("GET", "/api/agents/list") => super::agents::api_list(&req.query),
         ("GET", "/api/agents/manifest") => super::agents::api_manifest_info(),
         ("POST", "/api/agents/manifest/refresh") => super::agents::api_manifest_refresh(),


### PR DESCRIPTION
装了 Unterm 就有 Unzoo One 控制台，一个安装包把终端和浏览器一起装上，控制台里能真的跑起一个 agent。

## 做了什么

**1. 设置服务托管控制台**（`unterm-settings/src/console.rs`）
从磁盘服务控制台的构建产物，不需要第二个安装包。资源目录优先 `UNTERM_CONSOLE_DIR`（开发时指向 `dist/client`，改完前端刷新即可），否则用 exe 同级的 `console/`。`/console` 301 到 `/console/`；控制台 HTML 用绝对路径引资源，所以设置服务不认领的 GET 路径会兜底去 console 目录找 —— 设置页占 `/` 和 `/static/`，两边不撞。拒绝目录穿越。

没有 `include_str!` 进二进制：控制台是 1.4 MB、三十多个文件的构建产物，文件名带内容 hash 每次构建都变，嵌进去等于前端改一行就要重编 Rust。

**2. 菜单入口 + 进安装包**
`palette` 新增 `OpenConsole`，菜单项只在 `console_dir()` 找得到资源时才插入（没装就不显示，免得点开是 404）。九种语言各补 `settings.menu.console` / `.hint` 并登记进 i18n 守卫。`build-msi.ps1` 新增 `-ConsoleDir`，`Unterm.wxs` 用 `<Files Include>` 收整个目录（hash 文件名没法逐个写 Component）。

**3. Unzoo One 捆绑安装包**（`installer/UnzooOne.wxs` + `ci/build-bundle.ps1`）
Burn bundle 链 Unterm.msi + UnzooSetup.exe。刻意只做加法 —— Unterm.msi 原样携带、不重打包、UpgradeCode 不变，unterm 独立发布这条线一点没动。浏览器链为 `Vital=no`，它失败时终端仍可用；机器上已有同版本或更新的 Unzoo Browser 就按注册表 DisplayVersion 跳过那 183 MB。

**4. 控制台能真的跑一个 brain**（`unterm-settings/src/agent_run.rs`）
六条 HTTP 路由：`/api/agent/{start,events,status,input,interrupt,close}`。

安全形状是这里的重点：`agent_session.*` 在 MCP 上收的是 argv —— 对可信调用方是对的，放到 HTTP 后面就是任意命令执行。所以这些路由**收的是 agent id**，命令从 manifest 里那个 agent 的条目来，可执行路径来自 `installer::detect`（Windows 上是 .cmd shim，裸名字 spawn 不起来，实测过 program not found）。调用方的输入只进 prompt，走 stdin：它能决定跑哪个 agent、什么提示词、事件算在哪个 task/run/step 上，不能决定跑什么。

headless 参数写在 `agent_run` 里，不取 manifest 的 `launch.args`（那是写给终端前的人的）。不认识的 agent 一律拒绝。

## 验证

- **控制台托管**：隔离实例下 `/` 仍是设置页、`/console/` 是控制台，assets/favicon 全 200 且 content-type 正确；浏览器完整渲染、导航正常、零 401；穿越 `/console/../secret`、`%2f` 编码、`assets/../../` 全部 404
- **安装包**：有控制台产物 MSI 42 MB / 35 个文件，装完菜单出现；无产物 MSI 40 MB，构建照常通过、菜单不显示 —— 两种都实跑过。Bundle 产出 `UnzooOneSetup-0.71.0-x64.exe` 226 MB，含 Unterm 0.71.0 + Unzoo Browser 2.5.32；单独跑 `build-msi.ps1` 仍产出 42 MB MSI
- **agent 管道**：端到端跑通 —— start 返回 session_id 且 adapter 识别为 claude，events 拿到 session.started / turn.started / output.delta / usage×2 / turn.ended 且每条都带传入的 task_id/run_id/step_id，status 返回 state=finished，close 返回 exit_code。拒绝路径（未知 agent / 缺 prompt / 未认证）分别是明确错误、400、401
- **测试**：unterm-services 273 passed、unterm-settings 22 passed、unterm-app cargo check 零错误

## 已知未通的一处

agent 管道端到端实测时，claude 自己的认证返回 403 Request not allowed —— 因为那次是在一个 Claude Code 会话里嵌套 spawn claude CLI。管道到这一步为止全通，403 之前的每个环节都验过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019SYGZ1oDTb4TRqb2JszZ34